### PR TITLE
Atkinson @font-face

### DIFF
--- a/style.css
+++ b/style.css
@@ -3,7 +3,7 @@ html {
 }
 
 @font-face {
-  font-family: "Atkinson", "arial", sans-serif;
+  font-family: "Atkinson";
   src: url("./Atkinson-Hyperlegible-Regular-102.ttf") format("truetype");
 }
 


### PR DESCRIPTION
Le site s’affiche en Arial pour moi.

Je pense que c’est parce que la propriété font-family dans @font-face fait référence à toute la pile de typos plutôt qu’à Atkinson seulement? À tester :)

Au passage, il y a t-il une raison d’utiliser le TTF plutôt que la version WOFF2 ?